### PR TITLE
Remove binary starter archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# public
+# THEOPHYSICS Starter Kits
+
+This repository bundles a few building blocks for the THEOPHYSICS publishing
+stack:
+
+* **Cloudflare Worker + R2 starter** (`theophysics-worker/`) – serve Obsidian
+  notes directly from R2, including Durable Object–backed AI-only discussions.
+* **MkDocs + Cloudflare Pages CI starters** (`mkdocs-ci-starter/`) – three
+  ready-to-push MkDocs projects (public, research, private) each with a GitHub
+  Actions workflow targeting Cloudflare Pages.
+* **Obsidian distributor helper** (`vault-distributor/distribute.py`) – a
+  Python script that copies notes into the three MkDocs repos based on
+  frontmatter.
+
+> **Note:** Binary artifacts such as pre-built zip archives are not stored in
+> this repository. Create archives locally if you need packaged bundles of the
+> starter folders.

--- a/mkdocs-ci-starter/README.md
+++ b/mkdocs-ci-starter/README.md
@@ -1,0 +1,19 @@
+# MkDocs + Cloudflare Pages CI Starter (3 arms)
+
+Folders:
+- mkdocs-public
+- mkdocs-research
+- mkdocs-private
+
+Each contains:
+- mkdocs.yml
+- docs/index.md
+- requirements.txt
+- .github/workflows/deploy.yml
+
+Configure repo secrets per arm:
+- CLOUDFLARE_API_TOKEN
+- CLOUDFLARE_ACCOUNT_ID
+- CF_PAGES_PROJECT (unique per repo)
+
+Push to main → GitHub Action builds → Cloudflare Pages deploys.

--- a/mkdocs-ci-starter/mkdocs-private/.github/workflows/deploy.yml
+++ b/mkdocs-ci-starter/mkdocs-private/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Build & Deploy to Cloudflare Pages
+on:
+  push:
+    branches: [ "main" ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Build mkdocs
+        run: mkdocs build --clean --site-dir site
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ secrets.CF_PAGES_PROJECT }}
+          directory: site

--- a/mkdocs-ci-starter/mkdocs-private/docs/index.md
+++ b/mkdocs-ci-starter/mkdocs-private/docs/index.md
@@ -1,0 +1,6 @@
+---
+title: Welcome
+---
+# THEOPHYSICS — Private
+
+This site is generated from the Obsidian vault. Pages appear here when their frontmatter `arm:` equals `private`.

--- a/mkdocs-ci-starter/mkdocs-private/mkdocs.yml
+++ b/mkdocs-ci-starter/mkdocs-private/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: "THEOPHYSICS — Private"
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - content.code.copy
+    - toc.integrate
+markdown_extensions:
+  - admonition
+  - footnotes
+  - tables
+  - toc:
+      permalink: true
+nav:
+  - Home: index.md
+extra:
+  generator: false

--- a/mkdocs-ci-starter/mkdocs-private/requirements.txt
+++ b/mkdocs-ci-starter/mkdocs-private/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs
+mkdocs-material

--- a/mkdocs-ci-starter/mkdocs-public/.github/workflows/deploy.yml
+++ b/mkdocs-ci-starter/mkdocs-public/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Build & Deploy to Cloudflare Pages
+on:
+  push:
+    branches: [ "main" ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Build mkdocs
+        run: mkdocs build --clean --site-dir site
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ secrets.CF_PAGES_PROJECT }}
+          directory: site

--- a/mkdocs-ci-starter/mkdocs-public/docs/index.md
+++ b/mkdocs-ci-starter/mkdocs-public/docs/index.md
@@ -1,0 +1,6 @@
+---
+title: Welcome
+---
+# THEOPHYSICS — Public
+
+This site is generated from the Obsidian vault. Pages appear here when their frontmatter `arm:` equals `public`.

--- a/mkdocs-ci-starter/mkdocs-public/mkdocs.yml
+++ b/mkdocs-ci-starter/mkdocs-public/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: "THEOPHYSICS — Public"
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - content.code.copy
+    - toc.integrate
+markdown_extensions:
+  - admonition
+  - footnotes
+  - tables
+  - toc:
+      permalink: true
+nav:
+  - Home: index.md
+extra:
+  generator: false

--- a/mkdocs-ci-starter/mkdocs-public/requirements.txt
+++ b/mkdocs-ci-starter/mkdocs-public/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs
+mkdocs-material

--- a/mkdocs-ci-starter/mkdocs-research/.github/workflows/deploy.yml
+++ b/mkdocs-ci-starter/mkdocs-research/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Build & Deploy to Cloudflare Pages
+on:
+  push:
+    branches: [ "main" ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Build mkdocs
+        run: mkdocs build --clean --site-dir site
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ secrets.CF_PAGES_PROJECT }}
+          directory: site

--- a/mkdocs-ci-starter/mkdocs-research/docs/index.md
+++ b/mkdocs-ci-starter/mkdocs-research/docs/index.md
@@ -1,0 +1,6 @@
+---
+title: Welcome
+---
+# THEOPHYSICS — Research
+
+This site is generated from the Obsidian vault. Pages appear here when their frontmatter `arm:` equals `research`.

--- a/mkdocs-ci-starter/mkdocs-research/mkdocs.yml
+++ b/mkdocs-ci-starter/mkdocs-research/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: "THEOPHYSICS — Research"
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - content.code.copy
+    - toc.integrate
+markdown_extensions:
+  - admonition
+  - footnotes
+  - tables
+  - toc:
+      permalink: true
+nav:
+  - Home: index.md
+extra:
+  generator: false

--- a/mkdocs-ci-starter/mkdocs-research/requirements.txt
+++ b/mkdocs-ci-starter/mkdocs-research/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs
+mkdocs-material

--- a/theophysics-worker/.gitignore
+++ b/theophysics-worker/.gitignore
@@ -1,0 +1,2 @@
+.wrangler/
+node_modules/

--- a/theophysics-worker/README.md
+++ b/theophysics-worker/README.md
@@ -1,0 +1,33 @@
+# THEOPHYSICS — Cloudflare Worker + R2
+
+Dynamic Markdown render from R2 + per-note AI-only threads.
+
+## Setup
+
+1. Cloudflare R2 bucket: `theophysics-vault`
+2. KV namespace: create and replace `REPLACE_WITH_KV_ID` in `wrangler.toml`
+3. Durable Object: `NoteRoom` (auto via wrangler)
+
+Sync Obsidian to R2 (example using rclone):
+
+```
+rclone sync "O:\\THEOPHYSICS" r2:theophysics-vault/public --exclude ".obsidian/**"
+```
+
+Index format in KV (key/value):
+
+- `NOTE:<slug>` → `{"key":"public/your-note.md","slug":"your-note","title":"Title","tags":["t"]}`
+- `AIKEY:<agentId>` → shared secret for HMAC
+
+Run locally:
+
+```
+npm install
+npx wrangler dev
+```
+
+Deploy:
+
+```
+npx wrangler deploy
+```

--- a/theophysics-worker/package.json
+++ b/theophysics-worker/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "theophysics-worker",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "marked": "^12.0.2"
+  },
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  }
+}

--- a/theophysics-worker/src/index.js
+++ b/theophysics-worker/src/index.js
@@ -1,0 +1,181 @@
+// theophysics-worker: dynamic render from R2 + AI-only per-note threads
+import { marked } from "marked";
+
+export class NoteRoom {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+  }
+  async fetch(req) {
+    const url = new URL(req.url);
+    if (req.method === "POST" && url.pathname.endsWith("/append")) {
+      const body = await req.text();
+      await this.state.storage.put(Date.now().toString(), body);
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (req.method === "GET" && url.pathname.endsWith("/list")) {
+      const list = await this.state.storage.list({ reverse: true, limit: 100 });
+      const items = [];
+      for (const [k] of list.entries) {
+        const v = await this.state.storage.get(k);
+        items.push({ t: k, entry: v });
+      }
+      return new Response(JSON.stringify({ items }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("Not Found", { status: 404 });
+  }
+}
+
+async function hmacOk(env, id, sig, payload) {
+  if (!id || !sig) return false;
+  const secret = await env.NOTE_INDEX.get(`AIKEY:${id}`);
+  if (!secret) return false;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: env.HMAC_ALGO },
+    false,
+    ["sign"]
+  );
+  const digest = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload)
+  );
+  const hex = [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return hex === sig;
+}
+
+function shell(title, bodyHtml, extraHead = "") {
+  return new Response(
+    `<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${title}</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+${extraHead}
+</head><body><header><h1>${title}</h1></header><main>${bodyHtml}</main>
+<footer><small>THEOPHYSICS</small></footer></body></html>`,
+    { headers: { "content-type": "text/html; charset=utf-8" } }
+  );
+}
+
+async function renderNote(env, slug) {
+  const meta = await env.NOTE_INDEX.get(`NOTE:${slug}`, { type: "json" });
+  if (!meta) return new Response("Not found", { status: 404 });
+  const obj = await env.VAULT.get(meta.key);
+  if (!obj) return new Response("Missing object", { status: 404 });
+  const md = await obj.text();
+  const body = md.replace(/^---[\s\S]*?---\s*/, "");
+  const htmlBody = marked.parse(body);
+
+  const discuss = `<section>
+  <h2>AI Discussion</h2>
+  <form id="f"><textarea name="content" rows="5" required></textarea><br>
+  <input type="text" name="agent" placeholder="agent id" required>
+  <input type="text" name="sig" placeholder="hmac signature (hex)" required>
+  <button>Submit</button></form>
+  <div id="log"></div>
+<script>
+const f = document.getElementById('f');
+f.addEventListener('submit', async (e)=>{
+  e.preventDefault();
+  const data = new FormData(f);
+  const content = data.get('content');
+  const agent = data.get('agent');
+  const sig = data.get('sig');
+  const res = await fetch('/api/n/${slug}/replies', {
+    method: 'POST',
+    headers: {'content-type':'application/json','X-Agent-Id':agent,'X-Signature':sig},
+    body: JSON.stringify({ content })
+  });
+  document.getElementById('log').textContent = await res.text();
+});
+</script>
+</section>`;
+
+  return shell(meta.title || slug, htmlBody + discuss);
+}
+
+export default {
+  async fetch(req, env, ctx) {
+    const url = new URL(req.url);
+    const p = url.pathname;
+
+    if (req.method === "GET" && p === "/") {
+      return shell(
+        "THEOPHYSICS",
+        "<p>Dynamic notes from R2. Open /n/your-slug</p>"
+      );
+    }
+
+    const m = p.match(/^\/n\/([A-Za-z0-9\-_\/]+)$/);
+    if (req.method === "GET" && m) {
+      return renderNote(env, m[1]);
+    }
+
+    if (req.method === "GET" && p === "/api/search") {
+      const q = (url.searchParams.get("q") || "").toLowerCase();
+      const iter = await env.NOTE_INDEX.list({ prefix: "NOTE:" });
+      const out = [];
+      for (const k of iter.keys) {
+        const meta = await env.NOTE_INDEX.get(k.name, { type: "json" });
+        if (
+          meta &&
+          (meta.title?.toLowerCase().includes(q) ||
+            (meta.tags || []).join(" ").toLowerCase().includes(q))
+        ) {
+          out.push({ slug: meta.slug, title: meta.title, tags: meta.tags });
+        }
+      }
+      return new Response(JSON.stringify(out), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    const m2 = p.match(/^\/api\/n\/([A-Za-z0-9\-_\/]+)\/replies$/);
+    if (m2 && req.method === "POST") {
+      const slug = m2[1];
+      const bodyTxt = await req.text();
+      const ok = await hmacOk(
+        env,
+        req.headers.get("X-Agent-Id"),
+        req.headers.get("X-Signature"),
+        bodyTxt
+      );
+      if (!ok) return new Response("Forbidden", { status: 403 });
+      const id = env.NoteRoom.idFromName(slug);
+      const stub = env.NoteRoom.get(id);
+      return stub.fetch(
+        new Request(new URL(`http://room/${slug}/append`), {
+          method: "POST",
+          body: bodyTxt,
+        })
+      );
+    }
+
+    if (m2 && req.method === "GET") {
+      const slug = m2[1];
+      const id = env.NoteRoom.idFromName(slug);
+      const stub = env.NoteRoom.get(id);
+      return stub.fetch(
+        new Request(new URL(`http://room/${slug}/list`), { method: "GET" })
+      );
+    }
+
+    if (p === "/_cron" && req.method === "POST") {
+      return new Response("ok");
+    }
+    return new Response("Not Found", { status: 404 });
+  },
+
+  async scheduled(event, env, ctx) {
+    // TODO: list R2 objects (public/, research/, private/) and upsert NOTE_INDEX entries
+    // Example KV shape: NOTE:<slug> -> {"key":"public/Note.md","slug":"note-slug","title":"Note","tags":["t1"]}
+  },
+};

--- a/theophysics-worker/wrangler.toml
+++ b/theophysics-worker/wrangler.toml
@@ -1,0 +1,23 @@
+name = "theophysics-worker"
+main = "src/index.js"
+compatibility_date = "2025-10-01"
+
+# Bind your R2 bucket
+[[r2_buckets]]
+binding = "VAULT"
+bucket_name = "theophysics-vault"
+
+# KV for note index & AI keys
+[[kv_namespaces]]
+binding = "NOTE_INDEX"
+id = "REPLACE_WITH_KV_ID"
+
+# Durable Object for per-note discussion
+[durable_objects]
+bindings = [{ name = "NoteRoom", class_name = "NoteRoom" }]
+
+[vars]
+HMAC_ALGO = "SHA-256"
+
+[triggers]
+crons = ["*/15 * * * *"]

--- a/vault-distributor/README.md
+++ b/vault-distributor/README.md
@@ -1,0 +1,50 @@
+# Obsidian → MkDocs Distributor
+
+A small Python helper that copies Markdown notes from a single Obsidian vault
+into the three MkDocs starter repos provided in this project. Notes are routed
+by the `arm` key in their YAML frontmatter:
+
+```yaml
+---
+title: Logos Insertion Hypothesis
+arm: research      # public | research | private
+slug: logos-insertion-hypothesis
+---
+```
+
+## Requirements
+
+* Python 3.9+
+* [PyYAML](https://pyyaml.org/) (`pip install pyyaml`)
+
+## Usage
+
+1. Clone or unzip the MkDocs starters (`mkdocs-public`, `mkdocs-research`,
+   `mkdocs-private`) next to your Obsidian vault.
+2. From inside your vault directory, run:
+
+   ```bash
+   export PUB_REPO=../mkdocs-public
+   export RES_REPO=../mkdocs-research
+   export PRI_REPO=../mkdocs-private
+   python /path/to/distribute.py
+   ```
+
+   The environment variables are optional; the defaults above are used if they
+   are not set.
+3. Commit and push each MkDocs repo (GitHub Actions will build and deploy to
+   Cloudflare Pages using the provided workflow).
+
+## What the script does
+
+* Creates the `docs/` folder (and common asset directories) in each target
+  repository if needed.
+* Copies every Markdown file from the vault into the appropriate repo based on
+  the `arm` frontmatter (defaulting to `research`).
+* Mirrors shared asset folders (`assets`, `img`, `images`, `figures`,
+  `attachments`) into each repo so embedded media keeps working.
+
+## Extending the routing rules
+
+The logic lives in `Distributor.resolve_arm`. You can edit that function to
+implement more complex routing (e.g., tag-based, per-folder, etc.).

--- a/vault-distributor/distribute.py
+++ b/vault-distributor/distribute.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Distribute Obsidian Markdown files into separate MkDocs repos.
+
+Usage (run from inside your vault directory):
+
+    python /path/to/distribute.py
+
+The script expects the following environment variables to point to the
+matching MkDocs repos (defaults shown below):
+
+    PUB_REPO=../mkdocs-public
+    RES_REPO=../mkdocs-research
+    PRI_REPO=../mkdocs-private
+
+Each note can declare an ``arm`` in its YAML frontmatter.  Supported values
+are ``public``, ``research`` and ``private``.  Notes without ``arm`` default to
+``research``.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+try:
+    import yaml  # type: ignore
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency missing at runtime
+    raise SystemExit(
+        "PyYAML is required. Install it with `pip install pyyaml`."
+    ) from exc
+
+
+ARM_PUBLIC = "public"
+ARM_RESEARCH = "research"
+ARM_PRIVATE = "private"
+DEFAULT_ARM = ARM_RESEARCH
+
+ASSET_DIRS = {"assets", "img", "images", "figures", "attachments"}
+IGNORE_TOP_LEVEL = {".obsidian", ".git", "node_modules"}
+MARKDOWN_SUFFIXES = {".md", ".markdown"}
+
+
+@dataclass
+class RepoTarget:
+    name: str
+    path: Path
+
+    def docs_path(self) -> Path:
+        return self.path / "docs"
+
+
+class Distributor:
+    def __init__(self, vault: Path, repos: Dict[str, RepoTarget]) -> None:
+        self.vault = vault
+        self.repos = repos
+
+    # Frontmatter -----------------------------------------------------
+    @staticmethod
+    def parse_frontmatter(md_path: Path) -> Tuple[Dict[str, object], str]:
+        text = md_path.read_text(encoding="utf-8", errors="ignore")
+        match = re.match(r"^---\s*\r?\n(.*?)\r?\n---\s*\r?\n", text, re.DOTALL)
+        if not match:
+            return {}, text
+
+        fm_raw = match.group(1)
+        body = text[match.end() :]
+        try:
+            data = yaml.safe_load(fm_raw) or {}
+            if not isinstance(data, dict):
+                data = {}
+        except yaml.YAMLError:
+            data = {}
+        return data, body
+
+    # Utilities -------------------------------------------------------
+    @staticmethod
+    def slugify_relative(path: Path) -> Path:
+        cleaned_parts = []
+        for part in path.parts:
+            safe = re.sub(r"[^\w\-. ]+", "", part)
+            safe = safe.strip()
+            cleaned_parts.append(safe or part)
+        return Path(*cleaned_parts)
+
+    def ensure_repo_structure(self) -> None:
+        for target in self.repos.values():
+            target.docs_path().mkdir(parents=True, exist_ok=True)
+            for asset in ASSET_DIRS:
+                (target.docs_path() / asset).mkdir(parents=True, exist_ok=True)
+
+    def should_skip(self, rel_path: Path) -> bool:
+        if not rel_path.parts:
+            return False
+        top = rel_path.parts[0]
+        return top in IGNORE_TOP_LEVEL or top.startswith(".")
+
+    def resolve_arm(self, meta: Dict[str, object]) -> RepoTarget:
+        arm = str(meta.get("arm", "")).strip().lower()
+        target = self.repos.get(arm)
+        if target is None:
+            target = self.repos[DEFAULT_ARM]
+        return target
+
+    # Copying ---------------------------------------------------------
+    def copy_markdown(self, src: Path, dest_repo: RepoTarget, rel: Path) -> None:
+        dest_path = dest_repo.docs_path() / rel
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest_path)
+
+    def copy_assets(self) -> None:
+        for asset_dir in ASSET_DIRS:
+            source = self.vault / asset_dir
+            if source.exists() and source.is_dir():
+                for target in self.repos.values():
+                    shutil.copytree(source, target.docs_path() / asset_dir, dirs_exist_ok=True)
+
+    def distribute(self) -> None:
+        self.ensure_repo_structure()
+        for md in self.iter_markdown():
+            rel = md.relative_to(self.vault)
+            if self.should_skip(rel):
+                continue
+            meta, _ = self.parse_frontmatter(md)
+            repo = self.resolve_arm(meta)
+            safe_rel = self.slugify_relative(rel)
+            self.copy_markdown(md, repo, safe_rel)
+        self.copy_assets()
+
+    # Iteration -------------------------------------------------------
+    def iter_markdown(self) -> Iterable[Path]:
+        for path in self.vault.rglob("*"):
+            if path.is_file() and path.suffix.lower() in MARKDOWN_SUFFIXES:
+                yield path
+
+
+def build_repos_from_env() -> Dict[str, RepoTarget]:
+    vault = Path.cwd()
+    default_paths = {
+        ARM_PUBLIC: Path(os.environ.get("PUB_REPO", "../mkdocs-public")),
+        ARM_RESEARCH: Path(os.environ.get("RES_REPO", "../mkdocs-research")),
+        ARM_PRIVATE: Path(os.environ.get("PRI_REPO", "../mkdocs-private")),
+    }
+    repos: Dict[str, RepoTarget] = {}
+    for arm, path in default_paths.items():
+        repos[arm] = RepoTarget(arm, (vault / path).resolve()) if not path.is_absolute() else RepoTarget(arm, path)
+    return repos
+
+
+def main() -> None:
+    vault = Path.cwd()
+    repos = build_repos_from_env()
+    distributor = Distributor(vault, repos)
+    distributor.distribute()
+    print("Distributed notes into:")
+    for arm, target in repos.items():
+        print(f" - {arm}: {target.docs_path()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Cloudflare Worker starter project for rendering Obsidian notes from R2 with AI-gated discussions
- add a MkDocs starter structure for public, research, and private arms with Cloudflare Pages deployment workflow
- add an Obsidian-to-MkDocs distributor script that routes notes to the correct arm based on frontmatter and documents how to use it
- remove the pre-built starter zip archives and document that binaries should be created locally when needed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd96db4e748331bd77da3c3661cf05